### PR TITLE
Button support v2

### DIFF
--- a/things/.gitignore
+++ b/things/.gitignore
@@ -1,1 +1,2 @@
 /build
+/hardware.properties

--- a/things/build.gradle
+++ b/things/build.gradle
@@ -1,6 +1,22 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
+    }
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.novoda.build-properties'
+
+buildProperties {
+    hardwareConfig {
+        using project.file('hardware.properties')
+    }
+}
 
 android {
     compileSdkVersion 27
@@ -11,6 +27,10 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        // These config flags are loaded from hardware.properties, if present
+        buildConfigBoolean 'USE_RAINBOW_HAT', buildProperties.hardwareConfig['use_rainbow_hat'].or(false)
+        buildConfigBoolean 'NC_BUTTON', buildProperties.hardwareConfig['nc_button'].or(false)
     }
     buildTypes {
         release {

--- a/things/hardware.properties.sample
+++ b/things/hardware.properties.sample
@@ -1,0 +1,2 @@
+use_rainbow_hat=false
+nc_button=true

--- a/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
@@ -3,7 +3,6 @@ package net.bonysoft.doityourselfie
 import android.os.Build
 
 object BoardDefaults {
-    private const val USE_RAINBOW_HAT = true
 
     private const val DEVICE_RPI3 = "rpi3"
     private const val DEVICE_IMX6UL_PICO = "imx6ul_pico"
@@ -16,3 +15,6 @@ object BoardDefaults {
         else -> throw IllegalStateException("Unknown Build.DEVICE " + Build.DEVICE)
     }
 }
+
+private const val USE_RAINBOW_HAT = false
+internal const val NORMALLY_CLOSED_BUTTON = true

--- a/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
@@ -1,6 +1,7 @@
 package net.bonysoft.doityourselfie
 
 import android.os.Build
+import net.bonysoft.doityourselfie.BuildConfig.USE_RAINBOW_HAT
 
 object BoardDefaults {
 
@@ -22,6 +23,3 @@ object BoardDefaults {
         else -> throw IllegalStateException("Unknown Build.DEVICE " + Build.DEVICE)
     }
 }
-
-private const val USE_RAINBOW_HAT = false
-internal const val NORMALLY_CLOSED_BUTTON = true

--- a/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/BoardDefaults.kt
@@ -8,6 +8,13 @@ object BoardDefaults {
     private const val DEVICE_IMX6UL_PICO = "imx6ul_pico"
     private const val DEVICE_IMX7D_PICO = "imx7d_pico"
 
+    val gpioForLED = when (Build.DEVICE) {
+        DEVICE_RPI3 -> "BCM6"
+        DEVICE_IMX6UL_PICO -> "GPIO4_IO22"
+        DEVICE_IMX7D_PICO -> "GPIO2_IO02"
+        else -> throw IllegalStateException("Unknown Build.DEVICE " + Build.DEVICE)
+    }
+
     val gpioForButton = when (Build.DEVICE) {
         DEVICE_RPI3 -> if (USE_RAINBOW_HAT) "BCM21" else "BCM18"
         DEVICE_IMX6UL_PICO -> "GPIO2_IO03"

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : Activity() {
 
         if (BuildConfig.DEBUG) dumpFormatInfo(this)
 
-        val logicState = if (NORMALLY_CLOSED_BUTTON) Button.LogicState.PRESSED_WHEN_HIGH else Button.LogicState.PRESSED_WHEN_LOW
+        val logicState = if (BuildConfig.NC_BUTTON) Button.LogicState.PRESSED_WHEN_HIGH else Button.LogicState.PRESSED_WHEN_LOW
         buttonInputDriver = ButtonInputDriver(
             BoardDefaults.gpioForButton,
             logicState,

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -10,12 +10,15 @@ import android.view.KeyEvent
 import android.widget.ImageView
 import com.google.android.things.contrib.driver.button.Button
 import com.google.android.things.contrib.driver.button.ButtonInputDriver
+import com.google.android.things.pio.Gpio
+import com.google.android.things.pio.PeripheralManager
 import net.bonysoft.doityourselfie.camera.SelfieCamera
 import net.bonysoft.doityourselfie.camera.dumpFormatInfo
 import timber.log.Timber
 
 class MainActivity : Activity() {
 
+    private lateinit var ledGpio: Gpio
     private lateinit var buttonInputDriver: ButtonInputDriver
 
     private lateinit var camera: SelfieCamera
@@ -55,10 +58,24 @@ class MainActivity : Activity() {
 
             onPictureTaken(imageBytes)
         })
+
+        val pioService = PeripheralManager.getInstance()
+        ledGpio = pioService.openGpio(BoardDefaults.gpioForLED)
+        ledGpio.setDirection(Gpio.DIRECTION_OUT_INITIALLY_LOW)
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_SPACE) {
+            ledGpio.value = true
+            return true
+        }
+
+        return super.onKeyDown(keyCode, event)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_SPACE) {
+            ledGpio.value = false
             Timber.d("Button pressed")
             startShootingProcess()
             return true
@@ -74,6 +91,7 @@ class MainActivity : Activity() {
     override fun onStop() {
         buttonInputDriver.unregister()
         buttonInputDriver.close()
+        ledGpio.close()
         super.onStop()
     }
 

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -34,9 +34,10 @@ class MainActivity : Activity() {
 
         if (BuildConfig.DEBUG) dumpFormatInfo(this)
 
+        val logicState = if (NORMALLY_CLOSED_BUTTON) Button.LogicState.PRESSED_WHEN_HIGH else Button.LogicState.PRESSED_WHEN_LOW
         buttonInputDriver = ButtonInputDriver(
             BoardDefaults.gpioForButton,
-            Button.LogicState.PRESSED_WHEN_LOW,
+            logicState,
             KeyEvent.KEYCODE_SPACE)
         buttonInputDriver.register()
 


### PR DESCRIPTION
This PR adds support for both the Rainbow Hat and an external button, which can be both `normally open` or `normally closed`.
The configuration is read from a dedicated `.properties` file.
Also turning on an LED when pressing the button, as a confirmation