### PR TITLE
Token refresh + UI

### DIFF
--- a/things/build.gradle
+++ b/things/build.gradle
@@ -79,6 +79,8 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     compileOnly 'com.google.android.things:androidthings:1.0'
+    implementation 'com.google.android.things.contrib:driver-rainbowhat:1.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.23.4"

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -10,7 +10,6 @@ import android.os.HandlerThread
 import android.support.v7.app.AppCompatActivity
 import android.view.KeyEvent
 import android.widget.ImageView
-import android.widget.Toast
 import androidx.work.Constraints
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
@@ -163,7 +162,7 @@ class MainActivity : AppCompatActivity(), TokenReceiver {
             .build()
 
         with(WorkManager.getInstance()) {
-            cancelAllWorkByTag("upload")
+            cancelAllWorkByTag(workerTag)
             enqueue(workRequest)
             getStatusById(workRequest.id).observe(this@MainActivity, Observer { status ->
                 if (status != null) {

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -80,13 +80,12 @@ class MainActivity : AppCompatActivity(), TokenReceiver {
         if (Hawk.contains(TOKEN_KEY)) {
             Toast.makeText(this, "Logged in", Toast.LENGTH_SHORT).show()
             onTokenReceived(Hawk.get(TOKEN_KEY))
-        } else {
-            Toast.makeText(this, "Logged out", Toast.LENGTH_SHORT).show()
-            TokenManager.attachTo(this)
         }
+        TokenManager.attachTo(this)
     }
 
     override fun onTokenReceived(token: String) {
+        Timber.d("New token received")
         Hawk.put(TOKEN_KEY, token)
     }
 

--- a/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/MainActivity.kt
@@ -150,12 +150,16 @@ class MainActivity : AppCompatActivity(), TokenReceiver {
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 
+        val workerTag = "upload"
         val workRequest = OneTimeWorkRequest.Builder(PicturesUploadWorker::class.java)
             .setConstraints(uploadConstraints)
+            .addTag(workerTag)
             .build()
 
-        WorkManager.getInstance().enqueue(workRequest)
-        // TODO remove token and reattach listener in case of auth failure, to get an updated token
+        with(WorkManager.getInstance()) {
+            cancelAllWorkByTag("upload")
+            enqueue(workRequest)
+        }
     }
 
 }

--- a/things/src/main/java/net/bonysoft/doityourselfie/PicturesUploadWorker.kt
+++ b/things/src/main/java/net/bonysoft/doityourselfie/PicturesUploadWorker.kt
@@ -3,18 +3,28 @@ package net.bonysoft.doityourselfie
 import android.app.Application
 import android.arch.persistence.room.Room
 import android.graphics.BitmapFactory
+import androidx.work.Data
 import androidx.work.Worker
 import com.orhanobut.hawk.Hawk
 import kotlinx.coroutines.experimental.runBlocking
 import net.bonysoft.doityourselfie.MainActivity.Companion.TOKEN_KEY
 import net.bonysoft.doityourselfie.photos.PhotosAPI
 import net.bonysoft.doityourselfie.queue.QueueDatabase
+import retrofit2.HttpException
 import timber.log.Timber
+
+const val KEY_FAILURE_REASON = "failure_reason"
+
+enum class FailureReason {
+    AUTH,
+    NETWORK
+}
 
 class PicturesUploadWorker : Worker() {
 
     override fun doWork(): Result {
         if (!Hawk.contains(TOKEN_KEY)) {
+            outputData = Data.Builder().putString(KEY_FAILURE_REASON, FailureReason.AUTH.name).build()
             return Result.FAILURE
         }
 
@@ -45,6 +55,15 @@ class PicturesUploadWorker : Worker() {
                         Timber.d("Upload completed")
                         picturesUploadQueue.markPictureAsUploaded(picture.imageFile)
                     }
+                } catch (e: HttpException) {
+                    val reason = if (e.code() == 401) {
+                        FailureReason.AUTH
+                    } else {
+                        FailureReason.NETWORK
+                    }
+                    outputData = Data.Builder().putString(KEY_FAILURE_REASON, reason.name).build()
+                    Timber.e(e)
+                    allUploadsSuccessful = false
                 } catch (e: Exception) {
                     Timber.e(e)
                     allUploadsSuccessful = false


### PR DESCRIPTION
#### In this PR:

- always attach the token listener and start new upload worker in case of new token received
- cancel previously scheduled workers before scheduling a new one
- provide visual information of the status using Rainbow Hat. This includes:
-- `Sync` during pictures upload
-- `Auth` or `Netw` errors in case of failing workers
-- the number of pictures to be uploaded in other cases